### PR TITLE
Use explicit bit-count types.

### DIFF
--- a/Source/vectypes.h
+++ b/Source/vectypes.h
@@ -16,11 +16,11 @@
 #include <string.h>
 #include <stdint.h>
 
-typedef unsigned int uint;
-typedef unsigned short ushort;
-typedef unsigned long ulong;
-typedef unsigned char uchar;
-typedef signed char schar;
+typedef uint32_t uint;
+typedef uint16_t ushort;
+typedef uint64_t ulong;
+typedef uint8_t uchar;
+typedef int8_t schar;
 
 template < typename vtype > class vtype2;
 
@@ -9756,21 +9756,21 @@ typedef vtype4 < float >float4;
 typedef vtype2 < double >double2;
 typedef vtype3 < double >double3;
 typedef vtype4 < double >double4;
-typedef vtype2 < int >int2;
-typedef vtype3 < int >int3;
-typedef vtype4 < int >int4;
+typedef vtype2 < int32_t >int2;
+typedef vtype3 < int32_t >int3;
+typedef vtype4 < int32_t >int4;
 typedef vtype2 < uint > uint2;
 typedef vtype3 < uint > uint3;
 typedef vtype4 < uint > uint4;
-typedef vtype2 < short >short2;
-typedef vtype3 < short >short3;
-typedef vtype4 < short >short4;
+typedef vtype2 < int16_t >short2;
+typedef vtype3 < int16_t >short3;
+typedef vtype4 < int16_t >short4;
 typedef vtype2 < ushort > ushort2;
 typedef vtype3 < ushort > ushort3;
 typedef vtype4 < ushort > ushort4;
-typedef vtype2 < long >long2;
-typedef vtype3 < long >long3;
-typedef vtype4 < long >long4;
+typedef vtype2 < int64_t >long2;
+typedef vtype3 < int64_t >long3;
+typedef vtype4 < int64_t >long4;
 typedef vtype2 < ulong > ulong2;
 typedef vtype3 < ulong > ulong3;
 typedef vtype4 < ulong > ulong4;


### PR DESCRIPTION
When you compile the code with sanity checks, the warnings are emitted in the console, stating that a buffer overrun will happen if the respective functions with some magic numbers are called.

The problem is that the header in question seems ANCIENT. Somewhere in the distant past, the longs could really be 64 bits, but almost none use that convention currently, as longs are 32 bits under most compilers.

I have just altered the default types in the header to explicitly state the sizes of the ints. This way, there are no more warnings emitted regarding that issue.